### PR TITLE
user-input values saved to corresponding variables

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -12,19 +12,36 @@ var criteria = {
   lowerCase: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l","m", "n", "o", "p", "q", "r","s", "t", "u", "v", "w", "x", "y", "z"],
   upperCase: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L","M", "N", "O", "P", "Q", "R","S", "T", "U", "V", "W", "X", "Y", "Z"],
   specialChar: ["`", "~", "!", "@", "#", "$", "%", "^", "&", "*", "-","_", "=", "+"],
-  nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+  nums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
   
+  // When the process method is called it will store the user input values into corresponding variables
+  process: function() {
+    var lowerCaseIn = confirm("Would you like lowercase letters?");
+    console.log(lowerCaseIn);
+
+    var upperCaseIn = confirm("Would you like uppercase letters?");
+    console.log(upperCaseIn);
+
+    var specialCharIn = confirm("Would you like special characters?");
+    console.log(specialCharIn);
+  
+    var numsIn = confirm("Would you like numbers?");
+    console.log(numsIn);
+
+    
+  }
+
 }
 
 function generatePassword() {
 
   // Generates a pop=up for the user to respond with
   // User input will be stored within the passLen variable
-  var passLen = prompt("How long would you like your password? (8 characters minimum)");
+  var passLen = prompt("How long would you like your password? (8-20 characters)");
 
   // Compares passLen and checks if it's 8-20 characters long
   if (passLen >= criteria.minChar && passLen <= criteria.maxChar) {
-  
+    criteria.process();
   
   // If a user clicks cancel on the pop-up it will stop the function from running
   } else if (!passLen) {    
@@ -36,20 +53,6 @@ function generatePassword() {
     return;
   }
 
-
-  // Will need to store responses into a variable
-  confirm("Would you like lowercase letters?");
-
-
-  confirm("Would you like uppercase letters?");
-
-
-  confirm("Would you like special characters?");
-
-
-  confirm("Would you like numbers?");
-
-  // Find a way to take the boolean values from these responses and determine how the password is generated
 
   // Ensure that at least one of the pop-ups is selected to generate a password
   // Prevent user from selecting no on all answers


### PR DESCRIPTION
Relocated user-input values from pop-up responses (aside from initial character prompt) into a method within criteria.

Gave each response a variable to save user input values.

Corrected prompt text on line 40 to show 8-20 characters are required for the acceptance criteria.

Added comments to code to clarify it's purpose.